### PR TITLE
New "React Starter Kits and Toolchains" category

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,6 @@ A collection of awesome things regarding the React ecosystem.
 
 ##### React Development Tools
 
-- [create-react-app](https://github.com/facebook/create-react-app) - Set up a modern Web app by running one command
-- [react-starter-kit](https://github.com/kriasoft/react-starter-kit) - Isomorphic Web app boilerplate
 - [react-devtools](https://github.com/facebook/react-devtools) - Inspection of React component hierarchy in the Chrome and Firefox Developer Tools
 - [react-hot-loader](https://github.com/gaearon/react-hot-loader) - Tweak React components in real time
 - [react-loadable](https://github.com/jamiebuilds/react-loadable) - A higher order component for loading components with promises
@@ -177,6 +175,14 @@ A collection of awesome things regarding the React ecosystem.
 - [Why Did You Render](https://github.com/welldone-software/why-did-you-render) - Monkey patches React to notify you about avoidable re-renders.
 - [Divjoy](https://divjoy.com) - React codebase and UI generator to speed up development (paid)
 - [Plasmic](https://www.plasmic.app/) - Powerful design tool for building your React components visually.
+
+##### React Starter Kits and Toolchains
+
+- [create-react-app](https://github.com/facebook/create-react-app) - Set up a modern Web app by running one command
+- [Razzle](https://razzlejs.org/) - Build production ready React applications. Razzle is toolchain for modern static and dynamic websites and web applications.
+- [Neutrino React Preset](https://neutrinojs.org/packages/react/) - `@neutrinojs/react` is a Neutrino preset that supports building React web applications.
+- [react-starter-kit](https://github.com/kriasoft/react-starter-kit) - Isomorphic Web app boilerplate
+- [create-react-library](https://github.com/transitive-bullshit/create-react-library) - CLI for creating reusable, modern React libraries using Rollup and create-react-app.
 
 ##### React Frameworks
 


### PR DESCRIPTION
Changes:
- All react project starters are now moved under a new *React Starter Kits and Toolchains* category
- Added `Razzle`, `Neutrino` and `create-react-library` to *React Starter Kits and Toolchains*

fixes: https://github.com/enaqx/awesome-react/issues/1205